### PR TITLE
[DP][DDCE-925]: Fix file removal once downloaded

### DIFF
--- a/app/uk/gov/hmrc/rasapi/repository/RasChunksRepository.scala
+++ b/app/uk/gov/hmrc/rasapi/repository/RasChunksRepository.scala
@@ -49,10 +49,10 @@ class RasChunksRepository @Inject()(
 
   }
 
-  def removeChunk(filesId:BSONObjectID): Future[Boolean] = {
+  def removeChunk(filesId: BSONObjectID): Future[Boolean] = {
     val query = BSONDocument("files_id" -> filesId)
     collection.delete.one(query).map(res=> res.writeErrors.isEmpty).recover{
-      case ex:Throwable =>
+      case ex: Throwable =>
         Logger.error(s"[RasChunksRepository][removeChunk] error removing chunk ${filesId} with the exception ${ex.getMessage}.")
         false
     }

--- a/app/uk/gov/hmrc/rasapi/repository/RasFileRepository.scala
+++ b/app/uk/gov/hmrc/rasapi/repository/RasFileRepository.scala
@@ -104,9 +104,8 @@ class RasFilesRepository @Inject()(
       }
     }
 
-  // TODO: fileName and fileId are the same thing
-  def removeFile(fileName:String, fileId:String, userId: String): Future[Boolean] = {
-    logger.debug(s"file to remove => fileName: $fileName, file Id: $fileId for userId ($userId).")
+  def removeFile(fileName: String, userId: String): Future[Boolean] = {
+    logger.debug(s"file to remove => fileName: $fileName for userId ($userId).")
     getBsonObjectIdFromFileName(fileName).flatMap {
       case Some(bsonObjectId) =>
         logger.info(s"[RasFileRepository][removeFile] successfully got id for file. BSONObjectId: ${bsonObjectId.stringify}")

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ ScoverageKeys.coverageExcludedPackages  := "<empty>;" +
   "uk.gov.hmrc.rasapi.controllers.Documentation;" +
   "dev.*;" +
   "matching.*"
-ScoverageKeys.coverageMinimum           := 70
+ScoverageKeys.coverageMinimum           := 80
 ScoverageKeys.coverageFailOnMinimum     := false
 ScoverageKeys.coverageHighlighting      := true
 parallelExecution in Test               := false
@@ -60,12 +60,12 @@ lazy val silencerVersion = "1.7.1"
 libraryDependencies ++= Seq(
   ws,
   "uk.gov.hmrc"       %% "bootstrap-play-26"    % "2.3.0",
-  "uk.gov.hmrc"       %% "domain"               % "5.6.0-play-26",
-  "uk.gov.hmrc"       %% "mongo-caching"        % "6.15.0-play-26" excludeAll excludeIteratees,
+  "uk.gov.hmrc"       %% "domain"               % "5.10.0-play-26",
+  "uk.gov.hmrc"       %% "mongo-caching"        % "6.16.0-play-26" excludeAll excludeIteratees,
   "uk.gov.hmrc"       %% "simple-reactivemongo" % "7.31.0-play-26" excludeAll excludeIteratees,
-  "uk.gov.hmrc"       %% "json-encryption"      % "4.5.0-play-26",
+  "uk.gov.hmrc"       %% "json-encryption"      % "4.8.0-play-26",
   "uk.gov.hmrc"       %% "play-hmrc-api"        % "4.1.0-play-26",
-  "uk.gov.hmrc"       %% "http-caching-client"  % "9.0.0-play-26",
+  "uk.gov.hmrc"       %% "http-caching-client"  % "9.2.0-play-26",
   "com.typesafe.play" %% "play-iteratees-reactive-streams" % "2.6.1",
   "joda-time"         % "joda-time"             % "2.10.9",
   compilerPlugin("com.github.ghik" % "silencer-plugin" % silencerVersion cross CrossVersion.full),
@@ -84,12 +84,12 @@ dependencyOverrides ++= Seq(
 val scope = "test,it"
 
 libraryDependencies ++= Seq(
-  "uk.gov.hmrc"               %% "hmrctest"           % "3.9.0-play-26"   % scope,
+  "uk.gov.hmrc"               %% "hmrctest"           % "3.10.0-play-26"   % scope,
   "org.scalatest"             %% "scalatest"          % "3.0.9"           % scope,
   "org.pegdown"               %  "pegdown"            % "1.6.0"           % scope,
   "org.scalatestplus.play"    %% "scalatestplus-play" % "3.1.3"           % scope,
   "org.mockito"               %  "mockito-core"       % "3.3.3"           % scope,
-  "uk.gov.hmrc"               %% "reactivemongo-test" % "4.21.0-play-26"  % scope excludeAll excludeIteratees,
+  "uk.gov.hmrc"               %% "reactivemongo-test" % "4.22.0-play-26"  % scope excludeAll excludeIteratees,
   "com.typesafe.akka"         %  "akka-testkit_2.12"  % akkaVersion       % scope,
   "de.leanovate.play-mockws"  %% "play-mockws"        % "2.6.6"           % scope excludeAll excludeIteratees,
   "com.github.tomakehurst"    %  "wiremock-jre8"      % "2.21.0"          % scope

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,9 +1,9 @@
 # microservice specific routes
 
-POST     /residency-status                         uk.gov.hmrc.rasapi.controllers.LookupController.getResidencyStatus()
+POST    /residency-status                         uk.gov.hmrc.rasapi.controllers.LookupController.getResidencyStatus()
 
 POST    /ras-api/file-processing/status/:userId    uk.gov.hmrc.rasapi.controllers.FileProcessingController.statusCallback(userId, version ?= "1.0")
 
-GET  /ras-api/file/getFile/:name                   uk.gov.hmrc.rasapi.controllers.FileController.serveFile(name)
+GET     /ras-api/file/getFile/:name                uk.gov.hmrc.rasapi.controllers.FileController.serveFile(name)
 
-DELETE /ras-api/file/remove/:name/:id              uk.gov.hmrc.rasapi.controllers.FileController.remove(name,id)
+DELETE  /ras-api/file/remove/:name/:userid         uk.gov.hmrc.rasapi.controllers.FileController.remove(name, userid)

--- a/it/uk/gov/hmrc/rasapi/api/FileProcessingApiISpec.scala
+++ b/it/uk/gov/hmrc/rasapi/api/FileProcessingApiISpec.scala
@@ -57,7 +57,7 @@ class FileProcessingApiISpec extends PlaySpec with ScalaFutures
     ))
 
     def dropAll(): Boolean = {
-      await(rasFileRepository.removeFile(filename, filename, "userid-1"))
+      await(rasFileRepository.removeFile(filename, "userid-1"))
     }
   }
 

--- a/it/uk/gov/hmrc/rasapi/repositories/RasFileRepositoryISpec.scala
+++ b/it/uk/gov/hmrc/rasapi/repositories/RasFileRepositoryISpec.scala
@@ -100,7 +100,7 @@ class RasFileRepositoryISpec extends PlaySpec with ScalaFutures with GuiceOneApp
     "remove all chunks and files from the database" in new Setup("delete-file-name") {
       saveFile()
 
-      val deleteFile: Boolean = await(rasFileRepository.removeFile(filename, "fileId-1", "userid-1"))
+      val deleteFile: Boolean = await(rasFileRepository.removeFile(filename, "userid-1"))
       deleteFile mustBe true
 
       eventually(Timeout(5 seconds), Interval(1 second)) {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,3 +20,5 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.25")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
 addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.5.1")
+
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.5.0")

--- a/test/uk/gov/hmrc/rasapi/repositories/RasFileRepositorySpec.scala
+++ b/test/uk/gov/hmrc/rasapi/repositories/RasFileRepositorySpec.scala
@@ -75,7 +75,7 @@ class RasFileRepositorySpec extends UnitSpec with MockitoSugar with GuiceOneAppP
       val resultFile = await(RepositoriesHelper.saveTempFile("user222","envelope222","file222"))
       Logger.info(s"file to remove ---> name : ${resultFile.filename.get} id = ${resultFile.id}  " )
 
-      val res = await(rasFileRepository.removeFile(resultFile.filename.get,resultFile.id.toString, userId))
+      val res = await(rasFileRepository.removeFile(resultFile.filename.get, userId))
       res shouldBe true
 
       eventually(Timeout(5 seconds), Interval(1 second)){
@@ -92,7 +92,7 @@ class RasFileRepositorySpec extends UnitSpec with MockitoSugar with GuiceOneAppP
         resultFile.id.asInstanceOf[BSONObjectID]))
       // res.get.data. shouldBe tempFile
         res.isDefined shouldBe true
-      await(rasFileRepository.removeFile(resultFile.filename.get,resultFile.id.toString, userId))
+      await(rasFileRepository.removeFile(resultFile.filename.get, userId))
 
     }
 

--- a/test/uk/gov/hmrc/rasapi/repositories/RepositoriesHelper.scala
+++ b/test/uk/gov/hmrc/rasapi/repositories/RepositoriesHelper.scala
@@ -78,7 +78,7 @@ object RepositoriesHelper extends MongoSpecSupport with UnitSpec {
     await(TestFileWriter.generateFile(resultsArr.iterator))
   }
 
-  def saveTempFile(userID:String, envelopeID:String,fileId:String)(implicit rasFileRepository: RasFilesRepository): ResultsFile = {
+  def saveTempFile(userID: String, envelopeID: String, fileId: String)(implicit rasFileRepository: RasFilesRepository): ResultsFile = {
     val filePath = await(TestFileWriter.generateFile(tempFile.iterator))
     await(rasFileRepository.saveFile(userID, envelopeID, filePath, fileId))
   }


### PR DESCRIPTION
As per the output of [this spike](https://confluence.tools.tax.service.gov.uk/pages/viewpage.action?spaceKey=ELSE&title=DDCE-270%3A+RAS%3A+Investigate+failure+to+parse+file+on+RAS+backend) I've updated the BSONObjectId to take the fileName.
While working with this alongside the frontend I noticed the parameter names are not correct - the frontend sends the filename and user id to the endpoint that triggers `remove`, while the code was saying it was a file id. In that entire flow the fileId was just a duplicate of the userId so I've removed it.

We haven't been seeing the errors mentioned in the spike (failure to convert to BSON) in prod because the frontend has been calling the wrong endpoint (fixed in this pr: https://github.com/hmrc/ras-frontend/pull/264) but this should fix that also.

I also did some general spacing/consistency cleanup

## Checklist PR Raiser
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [ ]  I've squashed my commits - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date