### PR TITLE
[DDCE-1682][EH] reactivemongo to hmrc-mongo

### DIFF
--- a/app/uk/gov/hmrc/rasapi/config/AppContext.scala
+++ b/app/uk/gov/hmrc/rasapi/config/AppContext.scala
@@ -16,8 +16,9 @@
 
 package uk.gov.hmrc.rasapi.config
 
-import javax.inject.Inject
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+
+import javax.inject.Inject
 
 class AppContext @Inject()(val servicesConfig: ServicesConfig) {
   lazy val appName: String = servicesConfig.getString("appName")

--- a/app/uk/gov/hmrc/rasapi/connectors/FileUploadConnector.scala
+++ b/app/uk/gov/hmrc/rasapi/connectors/FileUploadConnector.scala
@@ -16,17 +16,16 @@
 
 package uk.gov.hmrc.rasapi.connectors
 
-import java.io.InputStream
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.StreamConverters
-
-import javax.inject.Inject
 import play.api.Logging
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.rasapi.config.{AppContext, WSHttp}
 import uk.gov.hmrc.rasapi.models.FileMetadata
 
+import java.io.InputStream
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class FileUploadConnector @Inject()(val wsHttp: WSHttp,

--- a/app/uk/gov/hmrc/rasapi/controllers/FileProcessingController.scala
+++ b/app/uk/gov/hmrc/rasapi/controllers/FileProcessingController.scala
@@ -16,14 +16,14 @@
 
 package uk.gov.hmrc.rasapi.controllers
 
-import javax.inject.Inject
 import play.api.Logging
 import play.api.libs.json.JsSuccess
-import play.api.mvc.{Action, AnyContent, ControllerComponents, Request, Result}
+import play.api.mvc._
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import uk.gov.hmrc.rasapi.models.{ApiVersion, CallbackData, V1_0, V2_0}
 import uk.gov.hmrc.rasapi.services.{FileProcessingService, SessionCacheService}
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Success, Try}
 

--- a/app/uk/gov/hmrc/rasapi/helpers/ResidencyYearResolver.scala
+++ b/app/uk/gov/hmrc/rasapi/helpers/ResidencyYearResolver.scala
@@ -16,8 +16,9 @@
 
 package uk.gov.hmrc.rasapi.helpers
 
-import javax.inject.Inject
 import org.joda.time.DateTime
+
+import javax.inject.Inject
 
 class ResidencyYearResolver @Inject()() {
 

--- a/app/uk/gov/hmrc/rasapi/metrics/Metrics.scala
+++ b/app/uk/gov/hmrc/rasapi/metrics/Metrics.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.rasapi.metrics
 
 import com.codahale.metrics.{MetricRegistry, Timer}
 import com.kenshoo.play.metrics.{Metrics => KenshooMetrics}
+
 import javax.inject.Inject
 
 class Metrics @Inject()(val metrics: KenshooMetrics){

--- a/app/uk/gov/hmrc/rasapi/models/CallbackData.scala
+++ b/app/uk/gov/hmrc/rasapi/models/CallbackData.scala
@@ -16,9 +16,9 @@
 
 package uk.gov.hmrc.rasapi.models
 
+import org.mongodb.scala.bson.ObjectId
 import play.api.libs.json.{Format, Json, OFormat}
-import reactivemongo.bson.BSONObjectID
-import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
+import uk.gov.hmrc.mongo.play.json.formats.MongoFormats
 
 case class FileMetadata(id: String, name: Option[String], created: Option[String])
 
@@ -32,17 +32,16 @@ object CallbackData {
   implicit val formats: OFormat[CallbackData] = Json.format[CallbackData]
 }
 
-case class ResultsFileMetaData (id: String, filename: Option[String],uploadDate: Option[Long], chunkSize: Int, length: Long)
+case class ResultsFileMetaData (id: String, filename: String,uploadDate: Long, chunkSize: Int, length: Long)
 
 object ResultsFileMetaData {
   implicit val formats: OFormat[ResultsFileMetaData] = Json.format[ResultsFileMetaData]
-
 }
 
-case class Chunks(_id:BSONObjectID, files_id:BSONObjectID)
+case class Chunks(_id: ObjectId, files_id: ObjectId)
 
 object Chunks {
-  implicit val objectIdformats: Format[BSONObjectID] = ReactiveMongoFormats.objectIdFormats
+  implicit val objectIdformats: Format[ObjectId] = MongoFormats.objectIdFormat
   implicit  val format: OFormat[Chunks] = Json.format[Chunks]
 }
 

--- a/app/uk/gov/hmrc/rasapi/models/RawMemberDetails.scala
+++ b/app/uk/gov/hmrc/rasapi/models/RawMemberDetails.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.rasapi.models
 
 import org.joda.time.DateTime
 import play.api.libs.functional.syntax._
-import play.api.libs.json.{JsPath, Json, OFormat, Reads, Writes}
+import play.api.libs.json._
 
 case class RawMemberDetails(nino: String = "",
                             firstName: String = "",

--- a/app/uk/gov/hmrc/rasapi/models/models.scala
+++ b/app/uk/gov/hmrc/rasapi/models/models.scala
@@ -18,16 +18,14 @@ package uk.gov.hmrc.rasapi
 
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
+import org.mongodb.scala.gridfs.GridFSFile
 import play.api.libs.json._
-import reactivemongo.api.BSONSerializationPack
-import reactivemongo.api.gridfs.ReadFile
-import reactivemongo.bson.BSONValue
 
 package object models {
 
   type NINO = String
   type Name = String
-  type ResultsFile = ReadFile[BSONSerializationPack.type, BSONValue]
+  type ResultsFile = GridFSFile
 
   object JsonReads {
 

--- a/app/uk/gov/hmrc/rasapi/repository/RasChunksRepository.scala
+++ b/app/uk/gov/hmrc/rasapi/repository/RasChunksRepository.scala
@@ -15,47 +15,36 @@
  */
 
 package uk.gov.hmrc.rasapi.repository
-
+import org.mongodb.scala.bson.{Document, ObjectId}
 import play.api.Logger
-import play.modules.reactivemongo.ReactiveMongoComponent
-import reactivemongo.api.Cursor
-import reactivemongo.bson.{BSONDocument, BSONObjectID}
-import reactivemongo.play.json.ImplicitBSONHandlers._
-import uk.gov.hmrc.mongo.ReactiveRepository
+import uk.gov.hmrc.mongo.MongoComponent
+import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
 import uk.gov.hmrc.rasapi.models.Chunks
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
-class RasChunksRepository @Inject()(
-                                     val mongoComponent: ReactiveMongoComponent,
-                                     implicit val ec: ExecutionContext
-                                   ) extends ReactiveRepository[Chunks, BSONObjectID](
-    collectionName = "resultsFiles.chunks",
-    mongo = mongoComponent.mongoConnector.db,
-    domainFormat = Chunks.format) {
+class RasChunksRepository @Inject()(val mongoComponent: MongoComponent)(implicit val ec: ExecutionContext) extends PlayMongoRepository[Chunks](
+  mongoComponent = mongoComponent,
+  collectionName = "resultsFiles.chunks",
+  domainFormat = Chunks.format,
+  indexes = Seq(),
+  replaceIndexes = false) {
 
   val log: Logger = Logger(getClass)
 
-  def getAllChunks: Future[Seq[Chunks]] ={
-    val query = BSONDocument("files_id" -> BSONDocument("$ne" -> "1"))
-    log.debug("********Remove chunks :Started*********")
-
-    // only fetch the id and files-id field for the result documents
-    val projection = BSONDocument("_id" -> 1, "files_id" -> 2)
-    collection.find(query,Some(projection)).cursor[Chunks]().collect[Seq](Int.MaxValue, Cursor.FailOnError()).recover {
+  def getAllChunks: Future[Seq[Chunks]] = {
+    collection.find(Document("files_id" -> Document("$ne" -> 1))).projection(Document("_id" -> 1, "files_id" -> 2)).collect.head.recover {
       case ex: Throwable =>
-        log.error(s"[RasChunksRepository][getAllChunks] Error fetching chunks  ${ex.getMessage}.", ex)
-        Seq.empty
+          log.error(s"[RasChunksRepository][getAllChunks] Error getting chunks: ${ex.getMessage}. Trace: $ex")
+          Seq.empty
     }
-
   }
 
-  def removeChunk(filesId: BSONObjectID): Future[Boolean] = {
-    val query = BSONDocument("files_id" -> filesId)
-    collection.delete.one(query).map(res=> res.writeErrors.isEmpty).recover{
+  def removeChunk(filesId: ObjectId): Future[Boolean] = {
+    collection.deleteOne(Document("files_id" -> filesId)).head.map(res => res.getDeletedCount != 0).recover {
       case ex: Throwable =>
-        log.error(s"[RasChunksRepository][removeChunk] error removing chunk $filesId with the exception ${ex.getMessage}.")
+        log.error(s"Error when attempting to remove chunk for file id $filesId. Exception: ${ex.getMessage}. Trace: $ex")
         false
     }
   }

--- a/app/uk/gov/hmrc/rasapi/services/AuditService.scala
+++ b/app/uk/gov/hmrc/rasapi/services/AuditService.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.rasapi.services
 
-import javax.inject.Inject
 import play.api.Configuration
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.audit.AuditExtensions._
@@ -24,6 +23,7 @@ import uk.gov.hmrc.play.audit.http.connector.{AuditConnector, AuditResult}
 import uk.gov.hmrc.play.audit.model.DataEvent
 import uk.gov.hmrc.rasapi.config.AppContext
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class AuditService @Inject()(

--- a/app/uk/gov/hmrc/rasapi/services/FileProcessingService.scala
+++ b/app/uk/gov/hmrc/rasapi/services/FileProcessingService.scala
@@ -127,18 +127,18 @@ class FileProcessingService @Inject()(
         result =>
           result match {
             case Success(file) =>
-              logger.info(s"[FileProcessingService][saveFile] Starting to save the file (${file.id}) for user ID: $userId")
+              logger.info(s"[FileProcessingService][saveFile] Starting to save the file (${file.getId}) for user ID: $userId")
 
-              val resultsFileMetaData = Some(ResultsFileMetaData(file.id.toString, file.filename, file.uploadDate, file.chunkSize, file.length))
+              val resultsFileMetaData = Some(ResultsFileMetaData(file.getId.toString, file.getFilename, file.getUploadDate.getTime, file.getChunkSize, file.getLength))
 
               fileUploadConnector.getFileMetadata(callbackData.envelopeId, callbackData.fileId, userId).onComplete {
                 case Success(metadata) =>
                   sessionCacheService.updateFileSession(userId, callbackData, resultsFileMetaData, metadata)
                 case Failure(ex) =>
-                  logger.error(s"[FileProcessingService][saveFile] Failed to get File Metadata for file (${file.id}), for user ID: $userId, message: ${ex.getMessage}", ex)
+                  logger.error(s"[FileProcessingService][saveFile] Failed to get File Metadata for file (${file.getId}), for user ID: $userId, message: ${ex.getMessage}", ex)
                   sessionCacheService.updateFileSession(userId, callbackData, resultsFileMetaData, None)
               }
-              logger.info(s"[FileProcessingService][saveFile] Completed saving the file (${file.id}) for user ID: $userId")
+              logger.info(s"[FileProcessingService][saveFile] Completed saving the file (${file.getId}) for user ID: $userId")
             case Failure(ex) =>
               logger.error(s"[FileProcessingService][saveFile] results file for userId ($userId) generation/saving failed with Exception ${ex.getMessage}", ex)
               sessionCacheService.updateFileSession(userId, callbackData.copy(status = STATUS_ERROR), None, None)

--- a/app/uk/gov/hmrc/rasapi/services/ResultsGenerator.scala
+++ b/app/uk/gov/hmrc/rasapi/services/ResultsGenerator.scala
@@ -25,8 +25,8 @@ import uk.gov.hmrc.rasapi.connectors.DesConnector
 import uk.gov.hmrc.rasapi.helpers.ResidencyYearResolver
 import uk.gov.hmrc.rasapi.models._
 
-import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
 import scala.util.{Failure, Success, Try}
 
 trait ResultsGenerator {

--- a/app/uk/gov/hmrc/rasapi/utils/ErrorConverter.scala
+++ b/app/uk/gov/hmrc/rasapi/utils/ErrorConverter.scala
@@ -16,9 +16,10 @@
 
 package uk.gov.hmrc.rasapi.utils
 
-import javax.inject.Inject
 import play.api.libs.json.{JsPath, JsonValidationError}
 import uk.gov.hmrc.rasapi.controllers.ErrorValidation
+
+import javax.inject.Inject
 
 class ErrorConverter @Inject()() {
 

--- a/build.sbt
+++ b/build.sbt
@@ -55,8 +55,7 @@ libraryDependencies ++= Seq(
   ws,
   "uk.gov.hmrc"       %% "bootstrap-backend-play-27"    % "5.2.0",
   "uk.gov.hmrc"       %% "domain"                       % "5.11.0-play-27",
-  "uk.gov.hmrc"       %% "mongo-caching"                % "7.0.0-play-27" excludeAll excludeIteratees,
-  "uk.gov.hmrc"       %% "simple-reactivemongo"         % "8.0.0-play-27" excludeAll excludeIteratees,
+  "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-27"           % "0.50.0",
   "uk.gov.hmrc"       %% "json-encryption"              % "4.10.0-play-27",
   "uk.gov.hmrc"       %% "play-hmrc-api"                % "6.2.0-play-27",
   "uk.gov.hmrc"       %% "http-caching-client"          % "9.4.0-play-27",
@@ -78,14 +77,14 @@ dependencyOverrides ++= Seq(
 val scope = "test,it"
 
 libraryDependencies ++= Seq(
-  "org.scalatest"             %% "scalatest"          % "3.0.9"          % scope,
-  "org.pegdown"               %  "pegdown"            % "1.6.0"          % scope,
-  "org.scalatestplus.play"    %% "scalatestplus-play" % "4.0.0"          % scope,
-  "org.mockito"               %  "mockito-core"       % "3.9.0"          % scope,
-  "uk.gov.hmrc"               %% "reactivemongo-test" % "5.0.0-play-27" % scope excludeAll excludeIteratees,
-  "com.typesafe.akka"         %  "akka-testkit_2.12"  % akkaVersion      % scope,
-  "de.leanovate.play-mockws"  %% "play-mockws"        % "2.6.6"          % scope excludeAll excludeIteratees,
-  "com.github.tomakehurst"    %  "wiremock-jre8"      % "2.21.0"         % scope
+  "org.scalatest"             %% "scalatest"                  % "3.0.9"          % scope,
+  "org.pegdown"               %  "pegdown"                    % "1.6.0"          % scope,
+  "uk.gov.hmrc.mongo"         %%  "hmrc-mongo-test-play-27"   % "0.50.0"         % scope,
+  "org.scalatestplus.play"    %% "scalatestplus-play"         % "4.0.0"          % scope,
+  "org.mockito"               %  "mockito-core"               % "3.9.0"          % scope,
+  "com.typesafe.akka"         %  "akka-testkit_2.12"          % akkaVersion      % scope,
+  "de.leanovate.play-mockws"  %% "play-mockws"                % "2.6.6"          % scope excludeAll excludeIteratees,
+  "com.github.tomakehurst"    %  "wiremock-jre8"              % "2.21.0"         % scope
 )
 
 scalacOptions ++= Seq(

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -55,6 +55,7 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"
 play.modules.enabled += "uk.gov.hmrc.rasapi.modules.APiModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule"
 play.modules.enabled += "com.kenshoo.play.metrics.PlayModule"
+play.modules.enabled += "uk.gov.hmrc.mongo.play.PlayMongoModule"
 
 play.http.errorHandler = "uk.gov.hmrc.rasapi.config.RasErrorHandler"
 

--- a/test/uk/gov/hmrc/rasapi/connectors/DesConnectorSpec.scala
+++ b/test/uk/gov/hmrc/rasapi/connectors/DesConnectorSpec.scala
@@ -17,15 +17,14 @@
 package uk.gov.hmrc.rasapi.connectors
 
 import org.joda.time.DateTime
-import org.mockito.ArgumentMatchers._
-import org.mockito.ArgumentMatchers.{eq => Meq}
+import org.mockito.ArgumentMatchers.{eq => Meq, _}
 import org.mockito.Mockito.{reset, times, verify, when}
 import org.scalatest.{BeforeAndAfter, Matchers, WordSpecLike}
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.libs.json.{JsValue, Json, OFormat}
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import uk.gov.hmrc.http._
-import uk.gov.hmrc.mongo.Awaiting
 import uk.gov.hmrc.play.bootstrap.http.DefaultHttpClient
 import uk.gov.hmrc.rasapi.config.AppContext
 import uk.gov.hmrc.rasapi.models._
@@ -33,7 +32,7 @@ import uk.gov.hmrc.rasapi.services.AuditService
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class DesConnectorSpec extends WordSpecLike with Matchers with GuiceOneAppPerSuite with BeforeAndAfter with MockitoSugar with Awaiting {
+class DesConnectorSpec extends WordSpecLike with Matchers with GuiceOneAppPerSuite with BeforeAndAfter with MockitoSugar {
 
   implicit val hc: HeaderCarrier = HeaderCarrier()
 

--- a/test/uk/gov/hmrc/rasapi/connectors/FileUploadConnectorSpec.scala
+++ b/test/uk/gov/hmrc/rasapi/connectors/FileUploadConnectorSpec.scala
@@ -27,15 +27,15 @@ import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.libs.json.Json
 import play.api.libs.ws.WSResponse
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, RequestTimeoutException}
-import uk.gov.hmrc.mongo.Awaiting
 import uk.gov.hmrc.rasapi.config.{AppContext, WSHttp}
 import uk.gov.hmrc.rasapi.models.FileMetadata
 
 import java.io.{BufferedReader, InputStreamReader}
 import scala.concurrent.{ExecutionContext, Future}
 
-class FileUploadConnectorSpec extends WordSpecLike with Matchers with Awaiting with GuiceOneAppPerSuite with MockitoSugar {
+class FileUploadConnectorSpec extends WordSpecLike with Matchers with GuiceOneAppPerSuite with MockitoSugar {
 
   implicit val hc: HeaderCarrier = HeaderCarrier()
 

--- a/test/uk/gov/hmrc/rasapi/controllers/FileProcessingControllerSpec.scala
+++ b/test/uk/gov/hmrc/rasapi/controllers/FileProcessingControllerSpec.scala
@@ -28,21 +28,20 @@ import play.api.libs.json.Json
 import play.api.mvc.ControllerComponents
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{defaultAwaitTimeout, status}
-import uk.gov.hmrc.mongo.Awaiting
 import uk.gov.hmrc.rasapi.models.{CallbackData, ResultsFileMetaData, V2_0}
 import uk.gov.hmrc.rasapi.services.{FileProcessingService, SessionCacheService}
 
 import scala.concurrent.ExecutionContext
 import scala.util.Random
 
-class FileProcessingControllerSpec extends WordSpecLike with Matchers with Awaiting with MockitoSugar with GuiceOneAppPerSuite with BeforeAndAfter {
+class FileProcessingControllerSpec extends WordSpecLike with Matchers with MockitoSugar with GuiceOneAppPerSuite with BeforeAndAfter {
 
   val envelopeId = "0b215ey97-11d4-4006-91db-c067e74fc653"
   val fileId = "file-id-1"
   val fileStatus = "AVAILABLE"
   val reason: Option[String] = None
   val callbackData: CallbackData = CallbackData(envelopeId, fileId, fileStatus, reason)
-  val resultsFile: ResultsFileMetaData = ResultsFileMetaData(fileId, Some("fileName.csv"), Some(1234L), 123, 1234L)
+  val resultsFile: ResultsFileMetaData = ResultsFileMetaData(fileId, "fileName.csv", 1234L, 123, 1234L)
   val userId: String = Random.nextInt(5).toString
 
   val mockFileProcessingService: FileProcessingService = mock[FileProcessingService]

--- a/test/uk/gov/hmrc/rasapi/controllers/LookupControllerSpec.scala
+++ b/test/uk/gov/hmrc/rasapi/controllers/LookupControllerSpec.scala
@@ -34,7 +34,6 @@ import play.mvc.Http.HeaderNames
 import uk.gov.hmrc.api.controllers.ErrorAcceptHeaderInvalid
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.mongo.Awaiting
 import uk.gov.hmrc.rasapi.config.AppContext
 import uk.gov.hmrc.rasapi.connectors.DesConnector
 import uk.gov.hmrc.rasapi.helpers.ResidencyYearResolver
@@ -45,7 +44,7 @@ import uk.gov.hmrc.rasapi.utils.ErrorConverter
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class LookupControllerSpec extends WordSpecLike with Matchers with Awaiting with MockitoSugar with GuiceOneAppPerSuite with BeforeAndAfter {
+class LookupControllerSpec extends WordSpecLike with Matchers with MockitoSugar with GuiceOneAppPerSuite with BeforeAndAfter {
 
   override implicit lazy val app: Application = new GuiceApplicationBuilder()
     .configure("api-v2_0.enabled" -> "true")

--- a/test/uk/gov/hmrc/rasapi/repositories/RepositoriesHelper.scala
+++ b/test/uk/gov/hmrc/rasapi/repositories/RepositoriesHelper.scala
@@ -16,22 +16,12 @@
 
 package uk.gov.hmrc.rasapi.repositories
 
-import java.io.{BufferedWriter, ByteArrayInputStream, FileWriter}
-import java.nio.file.{Files, Path}
-import play.api.{Application, Logger, Logging}
-import play.api.libs.iteratee.{Enumerator, Iteratee}
-import play.api.mvc.ControllerComponents
-import play.api.test.Helpers.stubControllerComponents
-import reactivemongo.api.DefaultDB
-import reactivemongo.api.commands.WriteResult
-import reactivemongo.bson.BSONDocument
-import uk.gov.hmrc.mongo.{Awaiting, MongoConnector, MongoSpecSupport}
-import uk.gov.hmrc.rasapi.models.ResultsFile
-import uk.gov.hmrc.rasapi.repository.{RasChunksRepository, RasFilesRepository}
+import play.api.Logging
+import play.api.libs.iteratee.Iteratee
 import uk.gov.hmrc.rasapi.services.RasFileWriter
 
-import scala.concurrent.{ExecutionContext, Future}
-import scala.io.Source
+import java.io.{BufferedWriter, FileWriter}
+import java.nio.file.{Files, Path}
 import scala.util.Random
 
 object TestFileWriter extends RasFileWriter with Logging {
@@ -54,65 +44,14 @@ object TestFileWriter extends RasFileWriter with Logging {
   }
 }
 
-object RepositoriesHelper extends MongoSpecSupport with Awaiting {
-
-  val cc: ControllerComponents = stubControllerComponents()
-  override implicit val ec: ExecutionContext = cc.executionContext
-
-  val hostPort: String = System.getProperty("mongoHostPort", "127.0.0.1:27017")
-  override val  databaseName = "ras-api"
-  val mongoConnector: () => DefaultDB = MongoConnector(s"mongodb://$hostPort/$databaseName").db
-
-  def rasFileRepository(implicit rasFilesRepository: RasFilesRepository): RasFileRepositoryTest = new RasFileRepositoryTest(rasFilesRepository)
-
+object RepositoriesHelper {
+  lazy val createFile: Path = TestFileWriter.generateFile(resultsArr.iterator)
   val resultsArr: Array[String] = Array("456C,John,Smith,1990-02-21,nino-INVALID_FORMAT",
     "AB123456C,John,Smith,1990-02-21,NOT_MATCHED",
     "AB123456C,John,Smith,1990-02-21,otherUKResident,scotResident")
-
-  val tempFile: Array[Any] = Array("TestMe START",1234345,"sdfjdkljfdklgj", "Test Me END")
-
-
-  lazy val createFile: Path = TestFileWriter.generateFile(resultsArr.iterator)
-
-  def saveTempFile(userID: String, envelopeID: String, fileId: String)(implicit rasFileRepository: RasFilesRepository): ResultsFile = {
-    val filePath: Path = TestFileWriter.generateFile(tempFile.iterator)
-    await(rasFileRepository.saveFile(userID, envelopeID, filePath, fileId))
-  }
-
-  case class FileData( data: Enumerator[Array[Byte]] = Enumerator.empty)
-
   def getAll: Iteratee[Array[Byte], Array[Byte]] = Iteratee.consume[Array[Byte]]()
-
-  class RasFileRepositoryTest(rfr: RasFilesRepository)(implicit ec: ExecutionContext)
-    extends RasFilesRepository(
-      rfr.mongoComponent,
-      rfr.appContext) with MongoSpecSupport {
-
-    override implicit val mongo: () => DefaultDB = mongoConnectorForTest.db
-
-    def getFile(storedFile: ResultsFile): Iterator[String] = {
-      val inputStream = gridFSG.enumerate(storedFile) run getAll map { bytes =>
-        new ByteArrayInputStream(bytes)
-      }
-      Source.fromInputStream(await(inputStream)).getLines
-    }
-
-    def remove(fileName:String): Future[WriteResult] = {gridFSG.files.delete.one(BSONDocument("filename"-> fileName))}
-  }
-
-  def rasBulkOperationsRepository(implicit app: Application): RasChunksRepository = app.injector.instanceOf[RasChunksRepository]
-
-  def createTestDataForDataCleansing(rasFilesRepository: RasFilesRepository): List[ResultsFile] = {
-    val fileNames = List("file1212","file1313")
-    val file1 = saveTempFile("user1212","envelope1212",fileNames.head)(rasFilesRepository)
-    val file2 = saveTempFile("user1313","envelope1313",fileNames.last)(rasFilesRepository)
-
-    await(rasFileRepository(rasFilesRepository).remove(fileNames.head))
-    await(rasFileRepository(rasFilesRepository).remove(fileNames.last))
-
-    List(file1,file2)
-  }
 }
+
 
 
 

--- a/test/uk/gov/hmrc/rasapi/services/AuditServiceSpec.scala
+++ b/test/uk/gov/hmrc/rasapi/services/AuditServiceSpec.scala
@@ -24,14 +24,13 @@ import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Configuration
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.mongo.Awaiting
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import uk.gov.hmrc.play.audit.model.DataEvent
 import uk.gov.hmrc.rasapi.config.AppContext
 
 import scala.concurrent.ExecutionContext
 
-trait AuditServiceSpec extends WordSpecLike with Matchers with Awaiting with MockitoSugar with GuiceOneAppPerSuite with BeforeAndAfter {
+trait AuditServiceSpec extends WordSpecLike with Matchers with MockitoSugar with GuiceOneAppPerSuite with BeforeAndAfter {
 
   implicit val hc: HeaderCarrier = HeaderCarrier()
   val mockAuditConnector: AuditConnector = mock[AuditConnector]

--- a/test/uk/gov/hmrc/rasapi/services/RasFileWriterSpec.scala
+++ b/test/uk/gov/hmrc/rasapi/services/RasFileWriterSpec.scala
@@ -20,13 +20,12 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfter, Matchers, WordSpecLike}
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
-import uk.gov.hmrc.mongo.Awaiting
 
 import java.nio.file.Files
 import scala.collection.mutable.ListBuffer
 import scala.io.Source
 
-class RasFileWriterSpec extends WordSpecLike with Matchers with Awaiting with GuiceOneServerPerSuite with ScalaFutures with MockitoSugar with BeforeAndAfter {
+class RasFileWriterSpec extends WordSpecLike with Matchers with GuiceOneServerPerSuite with ScalaFutures with MockitoSugar with BeforeAndAfter {
   object fileWriter extends RasFileWriter
 
   val resultsArr: Array[String] = Array("456C,John,Smith,1990-02-21,nino-INVALID_FORMAT",

--- a/test/uk/gov/hmrc/rasapi/services/SessionCacheServiceSpec.scala
+++ b/test/uk/gov/hmrc/rasapi/services/SessionCacheServiceSpec.scala
@@ -24,16 +24,15 @@ import org.scalatest.{BeforeAndAfter, Matchers, WordSpecLike}
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.libs.json.{JsValue, Json, Writes}
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.cache.client.{CacheMap, ShortLivedHttpCaching}
-import uk.gov.hmrc.mongo.Awaiting
 import uk.gov.hmrc.rasapi.models.{CallbackData, FileMetadata, FileSession, ResultsFileMetaData}
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class SessionCacheServiceSpec extends WordSpecLike
   with Matchers
-  with Awaiting
   with GuiceOneServerPerSuite
   with ScalaFutures
   with MockitoSugar
@@ -45,7 +44,7 @@ class SessionCacheServiceSpec extends WordSpecLike
   val originalFileName = "originalFileName"
   val reason: Option[String] = None
   val callbackData: CallbackData = CallbackData("1234", fileId, fileStatus, reason)
-  val resultsFile: ResultsFileMetaData = ResultsFileMetaData(fileId,Some("fileName.csv"),Some(1234L),123,1234L)
+  val resultsFile: ResultsFileMetaData = ResultsFileMetaData(fileId,"fileName.csv",1234L,123,1234L)
   val fileMetadata: FileMetadata = FileMetadata(fileId, None, None)
   val rasSession: FileSession = FileSession(Some(callbackData), Some(resultsFile), "userId", Some(DateTime.now().getMillis), Some(fileMetadata))
   val json: JsValue = Json.toJson(rasSession)


### PR DESCRIPTION
### DDCE-1682: reactivemongo to hmrc-mongo

- It was found during this migration that the appending of the TTL index to both mongo collections was unecessary and therefore this has been refactored to only append to the file metadata collection, see: https://jira.mongodb.org/browse/SERVER-23165. This is due to the chunks collection not having a date field.
- I was unable to figure out if `DataCleansingService` was being used by the service, but it seems this is resposible for cleaning up the chunks that have remained while the file metadata had been removed.
- The MongoDB GridFS library does operate slightly different, with a key difference being the automatic creation of the file and chunks collections. 

**Please merge the following first:**
https://github.com/hmrc/app-config-staging/pull/8605
https://github.com/hmrc/app-config-qa/pull/12092
https://github.com/hmrc/app-config-externaltest/pull/2387

## Checklist PR Raiser
- [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
- [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
- [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
- [x]  I've squashed my commits - including the JIRA issue number in the commit message
- [x]  I've run a dependency check to ensure all dependencies are up to date
