### PR TITLE
DDCE-3467 RAML to OAS migration.

### DIFF
--- a/app/uk/gov/hmrc/rasapi/controllers/Documentation.scala
+++ b/app/uk/gov/hmrc/rasapi/controllers/Documentation.scala
@@ -39,7 +39,7 @@ class Documentation @Inject()(appContext: AppContext,
     Ok(txt.definition(appContext.apiContext, appContext.apiStatus, appContext.endpointsEnabled, appContext.apiV2_0Enabled))
   }
 
-  def raml(version: String, file: String): Action[AnyContent] = {
+  def specification(version: String, file: String): Action[AnyContent] = {
     assets.at(s"/public/api/conf/$version", file)
   }
 }

--- a/app/uk/gov/hmrc/rasapi/repository/RasChunksRepository.scala
+++ b/app/uk/gov/hmrc/rasapi/repository/RasChunksRepository.scala
@@ -21,8 +21,7 @@ import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
 import uk.gov.hmrc.rasapi.models.Chunks
 
-import javax.inject.Inject
-import javax.inject.Singleton
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton

--- a/app/uk/gov/hmrc/rasapi/repository/RasChunksRepository.scala
+++ b/app/uk/gov/hmrc/rasapi/repository/RasChunksRepository.scala
@@ -22,8 +22,10 @@ import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
 import uk.gov.hmrc.rasapi.models.Chunks
 
 import javax.inject.Inject
+import javax.inject.Singleton
 import scala.concurrent.{ExecutionContext, Future}
 
+@Singleton
 class RasChunksRepository @Inject()(val mongoComponent: MongoComponent)(implicit val ec: ExecutionContext) extends PlayMongoRepository[Chunks](
   mongoComponent = mongoComponent,
   collectionName = "resultsFiles.chunks",

--- a/app/uk/gov/hmrc/rasapi/repository/RasFileRepository.scala
+++ b/app/uk/gov/hmrc/rasapi/repository/RasFileRepository.scala
@@ -27,8 +27,7 @@ import uk.gov.hmrc.rasapi.models.{Chunks, ResultsFile}
 
 import java.nio.ByteBuffer
 import java.nio.file.{Files, Path}
-import javax.inject.Inject
-import javax.inject.Singleton
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 case class FileData(length: Long = 0, data: Enumerator[Array[Byte]] = Enumerator.empty)

--- a/app/uk/gov/hmrc/rasapi/repository/RasFileRepository.scala
+++ b/app/uk/gov/hmrc/rasapi/repository/RasFileRepository.scala
@@ -28,10 +28,12 @@ import uk.gov.hmrc.rasapi.models.{Chunks, ResultsFile}
 import java.nio.ByteBuffer
 import java.nio.file.{Files, Path}
 import javax.inject.Inject
+import javax.inject.Singleton
 import scala.concurrent.{ExecutionContext, Future}
 
 case class FileData(length: Long = 0, data: Enumerator[Array[Byte]] = Enumerator.empty)
 
+@Singleton
 class RasFilesRepository @Inject()(val mongoComponent: MongoComponent,
                                    val appContext: AppContext)
                                    (implicit val ec: ExecutionContext) extends PlayMongoRepository[Chunks](

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ ScoverageKeys.coverageExcludedPackages  := "<empty>;" +
 ScoverageKeys.coverageMinimum           := 80
 ScoverageKeys.coverageFailOnMinimum     := false
 ScoverageKeys.coverageHighlighting      := true
-parallelExecution in Test               := false
+Test / parallelExecution                := false
 
 // build settings
 majorVersion := 1
@@ -37,26 +37,26 @@ PlayKeys.playDefaultPort := 9669
 
 scalaVersion                      := "2.12.12"
 retrieveManaged                   := true
-evictionWarningOptions in update  := EvictionWarningOptions.default.withWarnScalaVersionEviction(false)
+update / evictionWarningOptions   := EvictionWarningOptions.default.withWarnScalaVersionEviction(false)
 routesGenerator                   := InjectedRoutesGenerator
 
 // IT Settings
 DefaultBuildSettings.integrationTestSettings()
 
-unmanagedResourceDirectories in Compile += baseDirectory.value / "resources"
+Compile / unmanagedResourceDirectories += baseDirectory.value / "resources"
 
 // dependencies
 val akkaVersion = "2.6.16"
 val excludeIteratees = ExclusionRule("com.typesafe.play", "play-iteratees_2.12")
 lazy val silencerVersion = "1.7.1"
+val hmrcMongoVersion = "0.68.0"
 
 //compile dependencies
 libraryDependencies ++= Seq(
   ws,
   "uk.gov.hmrc"       %% "bootstrap-backend-play-28"    % "5.24.0",
   "uk.gov.hmrc"       %% "domain"                       % "6.2.0-play-28",
-  "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"           % "0.68.0",
-  "uk.gov.hmrc"       %% "json-encryption"              % "4.10.0-play-28",
+  "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"           % hmrcMongoVersion,
   "uk.gov.hmrc"       %% "play-hmrc-api"                % "6.4.0-play-28",
   "uk.gov.hmrc"       %% "http-caching-client"          % "9.5.0-play-28",
   "com.typesafe.play" %% "play-iteratees-reactive-streams" % "2.6.1",
@@ -84,7 +84,7 @@ libraryDependencies ++= Seq(
   "org.scalatestplus"         %% "mockito-3-4"                % "3.2.10.0"        % scope,
   "org.scalatestplus.play"    %% "scalatestplus-play"         % "5.1.0"           % scope,
   "org.pegdown"               %  "pegdown"                    % "1.6.0"           % scope,
-  "uk.gov.hmrc.mongo"         %% "hmrc-mongo-test-play-28"    % "0.54.0"          % scope,
+  "uk.gov.hmrc.mongo"         %% "hmrc-mongo-test-play-28"    % hmrcMongoVersion  % scope,
   "com.typesafe.akka"         %  "akka-testkit_2.12"          % akkaVersion       % scope,
   "de.leanovate.play-mockws"  %% "play-mockws"                % "2.8.1"           % scope excludeAll excludeIteratees,
   "com.github.tomakehurst"    %  "wiremock-jre8"              % "2.31.0"          % scope,

--- a/conf/application-json-logger.xml
+++ b/conf/application-json-logger.xml
@@ -5,10 +5,10 @@
         <encoder class="uk.gov.hmrc.play.logging.JsonEncoder"/>
     </appender>
 
-    <logger name="uk.gov" level="${logger.uk.gov:-INFO}"/>
-    <logger name="application" level="${logger.application:-INFO}"/>
+    <logger name="uk.gov" level="INFO"/>
+    <logger name="application" level="INFO"/>
 
-    <root level="${logger.application:-ERROR}">
+    <root level="ERROR">
         <appender-ref ref="STDOUT"/>
     </root>
 </configuration>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -18,12 +18,6 @@
 include "backend.conf"
 appName=ras-api
 
-# Secret key
-# ~~~~~
-# The secret key is used to secure cryptographics functions.
-# If you deploy your application to several instances be sure to use the same key!
-play.http.secret.key="iQYVJVhkXykMKBzvGw41hguSvZobTKjTA1PAYJl96JOujyVoH0S1E0dOOKaF8osh"
-
 # Session configuration
 # ~~~~~
 application.session.httpOnly=false
@@ -48,7 +42,7 @@ play.http.router=prod.Routes
 
 play.application.loader = "uk.gov.hmrc.play.bootstrap.ApplicationLoader"
 play.http.requestHandler = "uk.gov.hmrc.play.bootstrap.http.RequestHandler"
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuditModule"
+play.modules.enabled += "uk.gov.hmrc.play.audit.AuditModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.backend.BackendModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -59,6 +59,12 @@ play.modules.enabled += "uk.gov.hmrc.mongo.play.PlayMongoModule"
 
 play.http.errorHandler = "uk.gov.hmrc.rasapi.config.RasErrorHandler"
 
+# Uncomment below lines when previewing application.yaml file locally in case of CORS errors
+# play.filters.enabled += "play.filters.cors.CORSFilter"
+# play.filters.cors {
+#   allowedOrigins = ["http://localhost:9680"]
+# }
+
 # Controller
 # ~~~~~
 # By default all controllers will have authorisation, logging and
@@ -97,7 +103,6 @@ controllers {
     }
 
 }
-
 
 # Evolutions
 # ~~~~~

--- a/conf/definition.routes
+++ b/conf/definition.routes
@@ -2,4 +2,4 @@ GET        /api/definition                                  uk.gov.hmrc.rasapi.c
 
 GET        /api/documentation/:version/:endpointName        uk.gov.hmrc.rasapi.controllers.Documentation.documentation(version,endpointName)
 
-GET        /api/conf/:version/*file                         uk.gov.hmrc.rasapi.controllers.Documentation.raml(version, file)
+GET        /api/conf/:version/*file                         uk.gov.hmrc.rasapi.controllers.Documentation.specification(version, file)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.7.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy",url("https://open.artefacts.
 
 resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.5.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.8.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 

--- a/resources/public/api/conf/1.0/application.raml
+++ b/resources/public/api/conf/1.0/application.raml
@@ -7,12 +7,6 @@ protocols: [ HTTPS ]
 baseUri: http://api.service.hmrc.gov.uk
 
 documentation:
-  - title: Overview
-    content: !include documentation/overview.md
-  - title: Versioning
-    content: !include https://developer.service.hmrc.gov.uk/api-documentation/assets/common/docs/versioning.md
-  - title: Errors
-    content: !include https://developer.service.hmrc.gov.uk/api-documentation/assets/common/docs/errors.md
   - title: Testing the API
     content: !include documentation/testing-approach.md
 

--- a/resources/public/api/conf/1.0/application.yaml
+++ b/resources/public/api/conf/1.0/application.yaml
@@ -1,0 +1,175 @@
+openapi: 3.0.3
+info:
+  title: Residency status for relief at source
+  version: '1.0'
+servers:
+- url: https://test-api.service.hmrc.gov.uk
+  description: Sandbox
+- url: https://api.service.hmrc.gov.uk
+  description: Production
+paths:
+  /individuals/relief-at-source/residency-status:
+    post:
+      summary: Check if an individual is a Scottish resident
+      description: |
+        Find out if a scheme member pays tax in Scotland or in the rest of the UK, to tell you the rate of tax to use for their relief at source contributions.
+        From 1 January to 5 April each year you will get currentYearResidencyStatus and nextYearForecastResidencyStatus within the response json.
+        From 6 April to 31 December each year you will only get currentYearResidencyStatus within the response json.
+      operationId: checkIndividualResidency
+      parameters:
+        - $ref: '#/components/parameters/acceptHeader'
+        - $ref: '#/components/parameters/contentTypeHeader'
+        - $ref: '#/components/parameters/authorizationHeader'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              allOf:
+              - $ref: '#/components/schemas/residencyStatusRequest'
+            example:
+              nino: BB123456B
+              firstName: John
+              lastName: Smith
+              dateOfBirth: 1975-05-25
+        required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/residencyStatusResponse'
+              example:
+                currentYearResidencyStatus: otherUKResident
+                nextYearForecastResidencyStatus: scotResident
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/errorResponse'
+              example:
+                code: BAD_REQUEST
+                message: Bad Request
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/errorResponse'
+                - description: The pension scheme member's details do not match with HMRC's records.
+              example:
+                code: STATUS_UNAVAILABLE
+                message: Cannot provide a residency status for this pension scheme member.
+      deprecated: false
+      security:
+        - user-restricted:
+            - read:ras
+components:
+  parameters:
+    acceptHeader:
+      name: Accept
+      in: header
+      description: Specifies the response format and the [version](/api-documentation/docs/reference-guide#versioning) of the API to be used.
+      style: simple
+      schema:
+        type: string
+        enum:
+          - application/vnd.hmrc.1.0+json
+      required: true
+    contentTypeHeader:
+      name: Content-Type
+      in: header
+      description: Specifies the format of the request body, which must be JSON.
+      style: simple
+      schema:
+        type: string
+        enum:
+          - application/json
+      required: true
+    authorizationHeader:
+      name: Authorization
+      in: header
+      description: An [OAuth 2.0 Bearer Token](/api-documentation/docs/authorisation/user-restricted-endpoints) with the `read:ras` scope.
+      style: simple
+      schema:
+        type: string
+        example: Bearer bb7fed3fe10dd235a2ccda3d50fb
+      required: true
+  securitySchemes:
+    user-restricted:
+      type: oauth2
+      description: HMRC supports OAuth 2.0 for authenticating [user-restricted](https://developer.service.hmrc.gov.uk/api-documentation/docs/authorisation/user-restricted-endpoints) API requests using an OAuth 2.0 Bearer Token in the Authorization header.
+      flows:
+        authorizationCode:
+          authorizationUrl: https://api.service.hmrc.gov.uk/oauth/authorize
+          tokenUrl: https://api.service.hmrc.gov.uk/oauth/token
+          refreshUrl: https://api.service.hmrc.gov.uk/oauth/refresh
+          scopes:
+            read:ras: Access to Relief At Source API's
+  schemas:
+    residencyStatusRequest:
+      title: Residency status request
+      required:
+      - nino
+      - firstName
+      - lastName
+      - dateOfBirth
+      type: object
+      properties:
+        nino:
+          pattern: ^((?!(BG|GB|KN|NK|NT|TN|ZZ)|(D|F|I|Q|U|V)[A-Z]|[A-Z](D|F|I|O|Q|U|V))[A-Z]{2})[0-9]{6}[A-D]$
+          type: string
+          description: The pension scheme member’s National Insurance number.
+          example: BB123456B
+        firstName:
+          pattern: ^[a-zA-Z &`\-\'^]{1,35}$
+          type: string
+          description: The pension scheme member’s first name.
+          example: John
+        lastName:
+          pattern: ^[a-zA-Z &`\-\'^]{1,35}$
+          type: string
+          description: The pension scheme member’s last name.
+          example: Smith
+        dateOfBirth:
+          pattern: ^\d{4}-\d{2}-\d{2}$
+          type: string
+          description: The pension scheme member’s date of birth. This cannot be in the future.
+          example: 1975-05-25
+    residencyStatusResponse:
+      title: Relief at source residency status response
+      required:
+      - currentYearResidencyStatus
+      type: object
+      properties:
+        currentYearResidencyStatus:
+          $ref: '#/components/schemas/UKResidencyStatusType'
+        nextYearForecastResidencyStatus:
+          $ref: '#/components/schemas/UKResidencyStatusType'
+    UKResidencyStatusType:
+      title: UK residency status type
+      enum:
+      - scotResident
+      - otherUKResident
+      type: string
+    error-codeType:
+      title: errorCodeType
+      enum:
+      - BAD_REQUEST
+      - STATUS_UNAVAILABLE
+      type: string
+    errorResponse:
+      title: Error response
+      required:
+      - code
+      - message
+      type: object
+      properties:
+        code:
+          $ref: '#/components/schemas/error-codeType'
+        message:
+          type: string

--- a/resources/public/api/conf/1.0/application.yaml
+++ b/resources/public/api/conf/1.0/application.yaml
@@ -157,7 +157,7 @@ components:
       - otherUKResident
       type: string
     error-codeType:
-      title: errorCodeType
+      title: Error code type
       enum:
       - BAD_REQUEST
       - STATUS_UNAVAILABLE

--- a/resources/public/api/conf/1.0/documentation/overview.md
+++ b/resources/public/api/conf/1.0/documentation/overview.md
@@ -1,5 +1,5 @@
 
-Check if an pension scheme member is a resident in Scotland for tax purposes. 
+Check if a pension scheme member is a resident in Scotland for tax purposes. 
 If you’re a pension scheme administrator, you need to know this to make the correct relief at source claims.
 ##Before you start
 

--- a/resources/public/api/conf/2.0/application.raml
+++ b/resources/public/api/conf/2.0/application.raml
@@ -7,12 +7,6 @@ protocols: [ HTTPS ]
 baseUri: http://api.service.hmrc.gov.uk
 
 documentation:
-  - title: Overview
-    content: !include documentation/overview.md
-  - title: Versioning
-    content: !include https://developer.service.hmrc.gov.uk/api-documentation/assets/common/docs/versioning.md
-  - title: Errors
-    content: !include https://developer.service.hmrc.gov.uk/api-documentation/assets/common/docs/errors.md
   - title: Testing the API
     content: !include documentation/testing-approach.md
 

--- a/resources/public/api/conf/2.0/application.yaml
+++ b/resources/public/api/conf/2.0/application.yaml
@@ -1,0 +1,176 @@
+openapi: 3.0.3
+info:
+  title: Residency status for relief at source
+  version: '2.0'
+servers:
+- url: https://test-api.service.hmrc.gov.uk
+  description: Sandbox
+- url: https://api.service.hmrc.gov.uk
+  description: Production
+paths:
+  /individuals/relief-at-source/residency-status:
+    post:
+      summary: Check if an individual is a Scotland, Wales or rest of the UK resident
+      description: |
+        Pension Scheme Administrators can find out if a pension scheme member pays tax in Scotland, Wales or in the rest of the UK. They can apply the correct rate of Income Tax to their relief at source contributions.
+        From 1 January to 5 April, the API will return currentYearResidencyStatus and nextYearForecastResidencyStatus.
+        From 6 April to 31 December, the API will only return currentYearResidencyStatus.
+      operationId: checkIndividualResidency
+      parameters:
+        - $ref: '#/components/parameters/acceptHeader'
+        - $ref: '#/components/parameters/contentTypeHeader'
+        - $ref: '#/components/parameters/authorizationHeader'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              allOf:
+              - $ref: '#/components/schemas/residencyStatusRequest'
+            example:
+              nino: BB123456B
+              firstName: John
+              lastName: Smith
+              dateOfBirth: 1975-05-25
+        required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/residencyStatusResponse'
+              example:
+                currentYearResidencyStatus: otherUKResident
+                nextYearForecastResidencyStatus: scotResident
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/errorResponse'
+              example:
+                code: BAD_REQUEST
+                message: Bad Request
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/errorResponse'
+                - description: The pension scheme member's details do not match with HMRC's records.
+              example:
+                code: STATUS_UNAVAILABLE
+                message: Cannot provide a residency status for this pension scheme member.
+      deprecated: false
+      security:
+        - user-restricted:
+            - read:ras
+components:
+  parameters:
+    acceptHeader:
+      name: Accept
+      in: header
+      description: Specifies the response format and the [version](/api-documentation/docs/reference-guide#versioning) of the API to be used.
+      style: simple
+      schema:
+        type: string
+        enum:
+          - application/vnd.hmrc.2.0+json
+      required: true
+    contentTypeHeader:
+      name: Content-Type
+      in: header
+      description: Specifies the format of the request body, which must be JSON.
+      style: simple
+      schema:
+        type: string
+        enum:
+          - application/json
+      required: true
+    authorizationHeader:
+      name: Authorization
+      in: header
+      description: An [OAuth 2.0 Bearer Token](/api-documentation/docs/authorisation/user-restricted-endpoints) with the `read:ras` scope.
+      style: simple
+      schema:
+        type: string
+        example: Bearer bb7fed3fe10dd235a2ccda3d50fb
+      required: true
+  securitySchemes:
+    user-restricted:
+      type: oauth2
+      description: HMRC supports OAuth 2.0 for authenticating [user-restricted](https://developer.service.hmrc.gov.uk/api-documentation/docs/authorisation/user-restricted-endpoints) API requests using an OAuth 2.0 Bearer Token in the Authorization header.
+      flows:
+        authorizationCode:
+          authorizationUrl: https://api.service.hmrc.gov.uk/oauth/authorize
+          tokenUrl: https://api.service.hmrc.gov.uk/oauth/token
+          refreshUrl: https://api.service.hmrc.gov.uk/oauth/refresh
+          scopes:
+            read:ras: Access to Relief At Source API's
+  schemas:
+    residencyStatusRequest:
+      title: Residency status request
+      required:
+      - nino
+      - firstName
+      - lastName
+      - dateOfBirth
+      type: object
+      properties:
+        nino:
+          pattern: ^((?!(BG|GB|KN|NK|NT|TN|ZZ)|(D|F|I|Q|U|V)[A-Z]|[A-Z](D|F|I|O|Q|U|V))[A-Z]{2})[0-9]{6}[A-D]$
+          type: string
+          description: The pension scheme member’s National Insurance number.
+          example: BB123456B
+        firstName:
+          pattern: ^[a-zA-Z &`\-\'^]{1,35}$
+          type: string
+          description: The pension scheme member’s first name.
+          example: John
+        lastName:
+          pattern: ^[a-zA-Z &`\-\'^]{1,35}$
+          type: string
+          description: The pension scheme member’s last name.
+          example: Smith
+        dateOfBirth:
+          pattern: ^\d{4}-\d{2}-\d{2}$
+          type: string
+          description: The pension scheme member’s date of birth. This cannot be in the future.
+          example: 1975-05-25
+    residencyStatusResponse:
+      title: Relief at source residency status response
+      required:
+      - currentYearResidencyStatus
+      type: object
+      properties:
+        currentYearResidencyStatus:
+          $ref: '#/components/schemas/UKResidencyStatusType'
+        nextYearForecastResidencyStatus:
+          $ref: '#/components/schemas/UKResidencyStatusType'
+    UKResidencyStatusType:
+      title: UK residency status type
+      enum:
+      - scotResident
+      - welshResident
+      - otherUKResident
+      type: string
+    error-codeType:
+      title: errorCodeType
+      enum:
+      - BAD_REQUEST
+      - STATUS_UNAVAILABLE
+      type: string
+    errorResponse:
+      title: Error response
+      required:
+      - code
+      - message
+      type: object
+      properties:
+        code:
+          $ref: '#/components/schemas/error-codeType'
+        message:
+          type: string

--- a/resources/public/api/conf/2.0/application.yaml
+++ b/resources/public/api/conf/2.0/application.yaml
@@ -158,7 +158,7 @@ components:
       - otherUKResident
       type: string
     error-codeType:
-      title: errorCodeType
+      title: Error code type
       enum:
       - BAD_REQUEST
       - STATUS_UNAVAILABLE

--- a/resources/public/api/conf/common/overview.md
+++ b/resources/public/api/conf/common/overview.md
@@ -1,0 +1,8 @@
+Check a pension scheme member residency for tax purposes. 
+Pension scheme administrators need this for relief at source claims.
+
+### Before you start
+You will need the pension scheme member’s:
+* full name
+* date of birth
+* National Insurance number

--- a/resources/public/api/conf/common/testing.md
+++ b/resources/public/api/conf/common/testing.md
@@ -1,0 +1,6 @@
+You can use the sandbox environment to [test this API](https://developer.service.hmrc.gov.uk/api-documentation/docs/testing).
+
+It does not currently support [stateful behaviour](https://developer.service.hmrc.gov.uk/api-documentation/docs/testing/stateful-behaviour),
+but you can use the payloads described in Resources to test specific scenarios.
+
+You must set up a test user which is an organisation for this API using the [Create Test User API](https://developer.service.hmrc.gov.uk/api-documentation/docs/api/service/api-platform-test-user/1.0#_create-a-test-user-which-is-an-organisation_post_accordion).


### PR DESCRIPTION
# DDCE-3467

In this PR there were added new files needed for API spec conversion from RAML to OAS.
Addressed PR commenter recommendations.

Manually checked API spec generated from YAML file and all data was present. Used Preview OpenAPI from https://github.com/hmrc/api-documentation-frontend/

Run acceptance test packs locally.